### PR TITLE
Harden bookmark and wildcard input validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ Store reusable command bookmarks globally.
 
 Wildcards use `${name}` syntax and are resolved when running bookmarks.
 If a required wildcard is not provided, ScriptPal prompts for it.
+When passing wildcard values via CLI, use `name=value` pairs with non-empty names and values.
+
+Bookmark names must be non-empty and cannot be `__proto__`, `prototype`, or `constructor`.
 
 ## Examples
 

--- a/bin/index.js
+++ b/bin/index.js
@@ -61,7 +61,13 @@ function getConfig() {
 }
 
 function getBookmarks(config = getConfig()) {
-  return config.get(BOOKMARKS_KEY, {});
+  const bookmarks = config.get(BOOKMARKS_KEY, {});
+
+  if (!bookmarks || typeof bookmarks !== "object" || Array.isArray(bookmarks)) {
+    return {};
+  }
+
+  return bookmarks;
 }
 
 function getBookmark(name, config = getConfig()) {
@@ -77,13 +83,13 @@ function setPreviousBookmark(command, config = getConfig()) {
 }
 
 function setBookmark(name, command, config = getConfig()) {
-  const bookmarks = getBookmarks(config);
+  const bookmarks = { ...getBookmarks(config) };
   bookmarks[name] = command;
   config.set(BOOKMARKS_KEY, bookmarks);
 }
 
 function removeBookmark(name, config = getConfig()) {
-  const bookmarks = getBookmarks(config);
+  const bookmarks = { ...getBookmarks(config) };
 
   if (!bookmarks[name]) {
     throw new Error(chalk.red(`Bookmark "${name}" not found.`));
@@ -120,10 +126,41 @@ function parseWildcardArgs(wildcardPairs = []) {
 
     const name = pair.slice(0, separatorIndex);
     const value = pair.slice(separatorIndex + 1);
+    const normalizedName = name.trim();
 
-    values[name] = value;
+    if (!normalizedName) {
+      throw new Error(
+        chalk.red(
+          `Invalid wildcard "${pair}". Wildcard name cannot be empty.`,
+        ),
+      );
+    }
+
+    if (value.length === 0) {
+      throw new Error(
+        chalk.red(
+          `Invalid wildcard "${pair}". Wildcard value cannot be empty.`,
+        ),
+      );
+    }
+
+    values[normalizedName] = value;
     return values;
   }, {});
+}
+
+function isValidBookmarkName(name) {
+  if (!name || typeof name !== "string") {
+    return false;
+  }
+
+  const normalized = name.trim();
+
+  if (!normalized) {
+    return false;
+  }
+
+  return !["__proto__", "prototype", "constructor"].includes(normalized);
 }
 
 async function resolveWildcards(command, wildcardPairs = []) {
@@ -223,6 +260,10 @@ async function listBookmarks() {
 }
 
 async function addBookmark(name, commandParts) {
+  if (!isValidBookmarkName(name)) {
+    throw new Error(chalk.red("Invalid bookmark name."));
+  }
+
   const command = commandParts.join(" ").trim();
 
   if (!command) {
@@ -240,6 +281,10 @@ async function addBookmark(name, commandParts) {
 }
 
 async function editBookmark(name, commandParts) {
+  if (!isValidBookmarkName(name)) {
+    throw new Error(chalk.red("Invalid bookmark name."));
+  }
+
   const command = commandParts.join(" ").trim();
 
   if (!command) {


### PR DESCRIPTION
### Motivation
- Prevent crashes and unsafe behavior when persisted bookmark storage contains malformed data or unexpected types.
- Avoid accepting empty or malformed wildcard CLI pairs which previously could produce confusing substitutions or silent failures.
- Prevent creation of bookmarks with dangerous prototype-related keys (`__proto__`, `prototype`, `constructor`) to avoid mutation attacks or accidental corruption.

### Description
- Validate the shape of persisted bookmarks returned from `Conf` in `getBookmarks` and return an empty object for unexpected values to avoid runtime errors.
- Clone bookmark objects before mutating in `setBookmark` and `removeBookmark` to avoid mutating unexpected shared references. (`{ ...getBookmarks(config) }`).
- Improve `parseWildcardArgs` to `trim()` wildcard names and reject pairs with empty names or empty values, throwing a clear error for invalid input.
- Add `isValidBookmarkName` and apply it in `addBookmark` and `editBookmark` to reject empty or reserved prototype-related bookmark names, and document the constraints in `README.md`.

### Testing
- `node --check bin/index.js` succeeded.
- `node --check bin/prompts.js` succeeded.
- `npm ci` was attempted but failed in this environment due to an external npm registry `403 Forbidden` for `@types/node`, so full install-time tests could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9f1faa63083218ef7b811f23228af)