### PR TITLE
docs: add help examples showing how to preserve wildcard placeholders in bookmarks

### DIFF
--- a/.changeset/tasty-pans-relate.md
+++ b/.changeset/tasty-pans-relate.md
@@ -1,0 +1,5 @@
+---
+"scriptpal": patch
+---
+
+Add bookmark help examples that show how to preserve wildcard placeholders using single quotes or escaped dollar signs in double quotes.

--- a/bin/index.js
+++ b/bin/index.js
@@ -331,7 +331,8 @@ Examples
   $ npx scriptpal
   $ scriptpal start
   $ scriptpal bookmark --last
-  $ scriptpal bookmark add testpkg "yarn test src/packages/\${package}"
+  $ scriptpal bookmark add testpkg 'yarn test src/packages/\${package}'
+  $ scriptpal bookmark add testpkg "yarn test src/packages/\\\${package}"
   $ scriptpal bookmark run testpkg package=ui-button`,
   )
   .argument("[script]")
@@ -355,6 +356,8 @@ const bookmarkCommand = program
 Examples
   $ scriptpal bookmark
   $ scriptpal bookmark --last
+  $ scriptpal bookmark add testpkg 'yarn test src/packages/\${package}'
+  $ scriptpal bookmark add testpkg "yarn test src/packages/\\\${package}"
   $ scriptpal bookmark run testpkg package=ui-button`,
   )
   .action((options) => pickAndRunBookmark(options));


### PR DESCRIPTION
### Motivation
- Clarify how to preserve wildcard placeholders in bookmark commands by demonstrating single-quote usage and escaping the `$` in double-quoted strings.
- Include a changeset for this documentation patch so the help text change is tracked in the release notes.

### Description
- Updated the CLI help text in `bin/index.js` to add examples showing `scriptpal bookmark add testpkg 'yarn test src/packages/\${package}'` and `scriptpal bookmark add testpkg "yarn test src/packages/\\${package}"` to demonstrate single quotes and escaped dollar signs. 
- Added a new changeset file `.changeset/tasty-pans-relate.md` describing the patch for release.

### Testing
- No automated tests were added or changed for this documentation/help-only update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc6d5356488321841f74fa9cbebd0a)