### PR TITLE
Sort bookmark names alphabetically and add unit tests

### DIFF
--- a/.changeset/silent-stingrays-flash.md
+++ b/.changeset/silent-stingrays-flash.md
@@ -1,0 +1,5 @@
+---
+"scriptpal": patch
+---
+
+Sort bookmark names alphabetically when listing bookmarks and in the interactive bookmark picker.

--- a/bin/bookmarks.js
+++ b/bin/bookmarks.js
@@ -1,0 +1,14 @@
+"use strict";
+
+function sortBookmarksByName(entries) {
+  return [...entries].sort(([leftName], [rightName]) =>
+    leftName.localeCompare(rightName, undefined, {
+      sensitivity: "base",
+      numeric: true,
+    }),
+  );
+}
+
+module.exports = {
+  sortBookmarksByName,
+};

--- a/bin/index.js
+++ b/bin/index.js
@@ -24,6 +24,7 @@ const {
   parseWildcardArgs,
   resolveWildcardTemplate,
 } = require("./wildcards");
+const { sortBookmarksByName } = require("./bookmarks");
 
 const BOOKMARKS_KEY = "bookmarks";
 const BOOKMARK_PREVIOUS_KEY = "bookmark.previous";
@@ -182,7 +183,7 @@ async function list() {
 
 async function listBookmarks() {
   const bookmarks = getBookmarks();
-  const entries = Object.entries(bookmarks);
+  const entries = sortBookmarksByName(Object.entries(bookmarks));
 
   if (entries.length === 0) {
     console.log("No bookmarks saved yet.");
@@ -271,7 +272,9 @@ async function pickAndRunBookmark(options = {}) {
   }
 
   const bookmarks = getBookmarks();
-  const names = Object.keys(bookmarks);
+  const names = sortBookmarksByName(Object.entries(bookmarks)).map(
+    ([name]) => name,
+  );
 
   if (names.length === 0) {
     console.log("No bookmarks saved yet.");

--- a/test/bookmarks.test.mjs
+++ b/test/bookmarks.test.mjs
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import bookmarks from "../bin/bookmarks.js";
+
+const { sortBookmarksByName } = bookmarks;
+
+describe("sortBookmarksByName", () => {
+  it("sorts bookmark names alphabetically", () => {
+    const sorted = sortBookmarksByName([
+      ["zebra", "echo zebra"],
+      ["alpha", "echo alpha"],
+      ["middle", "echo middle"],
+    ]);
+
+    expect(sorted.map(([name]) => name)).toEqual(["alpha", "middle", "zebra"]);
+  });
+
+  it("sorts case-insensitively and keeps numeric order", () => {
+    const sorted = sortBookmarksByName([
+      ["task10", "echo 10"],
+      ["Task2", "echo 2"],
+      ["task1", "echo 1"],
+    ]);
+
+    expect(sorted.map(([name]) => name)).toEqual(["task1", "Task2", "task10"]);
+  });
+});


### PR DESCRIPTION
### Motivation
- Ensure bookmarks are displayed and picked in a predictable, user-friendly alphabetical order.

### Description
- Add `bin/bookmarks.js` exporting `sortBookmarksByName` that performs a locale-aware, case-insensitive, numeric-aware sort of bookmark entries.
- Use `sortBookmarksByName` in `listBookmarks` and `pickAndRunBookmark` inside `bin/index.js` so listed names and the interactive picker are sorted.
- Add unit tests in `test/bookmarks.test.mjs` to validate alphabetical, case-insensitive, and numeric ordering behavior.
- Add a changeset file `.changeset/silent-stingrays-flash.md` documenting the patch.

### Testing
- Added unit tests for `sortBookmarksByName` and ran the test suite with `vitest`; the new tests passed.
- Ran `npm test` (which invokes the automated test runner) and the test run succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6aaf87c8c83219a85295b8cfce30d)